### PR TITLE
Only use reasoing effor high if the request model is opus 4.1

### DIFF
--- a/.env.deepseek
+++ b/.env.deepseek
@@ -1,0 +1,5 @@
+OPENAI_API_KEY=sk-xxx-e00
+BIG_MODEL_NAME=deepseek/deepseek-reasoner
+SMALL_MODEL_NAME=deepseek/deepseek-chat
+LOG_LEVEL=DEBUG
+OPENAI_BASE_URL=https://api.deepseek.com/v1

--- a/ccproxy/config.py
+++ b/ccproxy/config.py
@@ -67,12 +67,18 @@ SUPPORT_DEVELOPER_MESSAGE_MODELS: FrozenSet[str] = frozenset(
 )
 
 # Models that are in the top tier of the OpenAI API
-TOP_TIER_MODELS: FrozenSet[str] = frozenset(
+TOP_TIER_OPENAI_MODELS: FrozenSet[str] = frozenset(
     {
         "o3",
         "o3-2025-04-16",
         "gpt-5-2025-08-07",
         "gpt-5",
+    }
+)
+
+TOP_TIER_ANTHROPIC_MODELS: FrozenSet[str] = frozenset(
+    {
+        "claude-opus-4-1-20250805",
     }
 )
 

--- a/ccproxy/interfaces/http/routes/messages.py
+++ b/ccproxy/interfaces/http/routes/messages.py
@@ -11,7 +11,8 @@ from ....application.response_cache import ResponseCache
 
 from ....config import (
     MODEL_MAX_OUTPUT_TOKEN_LIMIT_MAP,
-    TOP_TIER_MODELS,
+    TOP_TIER_ANTHROPIC_MODELS,
+    TOP_TIER_OPENAI_MODELS,
     ReasoningEfforts,
     Settings,
     NO_SUPPORT_TEMPERATURE_MODELS,
@@ -117,9 +118,10 @@ async def create_message_proxy(request: Request) -> Response:
         )
 
     is_stream = bool(anthropic_request.stream)
+    request_model = anthropic_request.model
 
     target_model = select_target_model(
-        anthropic_request.model,
+        request_model,
         request_id,
         settings.big_model_name,
         settings.small_model_name,
@@ -295,11 +297,11 @@ async def create_message_proxy(request: Request) -> Response:
         and target_model in SUPPORT_REASONING_EFFORT_MODELS
     ):
         reasoning_effort = (
-            ReasoningEfforts.High.value
+            (ReasoningEfforts.High.value if request_model in TOP_TIER_ANTHROPIC_MODELS else ReasoningEfforts.Medium.value)
             if is_stream
             else (
                 ReasoningEfforts.Low.value
-                if target_model in TOP_TIER_MODELS
+                if target_model in TOP_TIER_OPENAI_MODELS
                 else ReasoningEfforts.Medium.value
             )
         )


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration

___

### **PR Description**
- Added `TOP_TIER_ANTHROPIC_MODELS` constant with `claude-opus-4-1-20250805`.

- Modified reasoning effort logic to use `High` only for Anthropic Opus 4.1 models.

- Updated OpenAI top tier models constant name to `TOP_TIER_OPENAI_MODELS`.

- Added DeepSeek configuration file with API settings.
